### PR TITLE
Support custom query parser in execute_graphql_request

### DIFF
--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -171,7 +171,7 @@ def execute_graphql_request(schema, params, allow_only_query=False, parser=parse
         raise HttpQueryError(400, 'Must provide query string.')
 
     try:
-        ast, validation_errors = parse_query(params.query, schema)
+        ast, validation_errors = parser(params.query, schema)
         if validation_errors:
             return ExecutionResult(
                 errors=validation_errors,

--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -159,14 +159,19 @@ def format_execution_result(execution_result, format_error):
     return GraphQLResponse(response, status_code)
 
 
-def execute_graphql_request(schema, params, allow_only_query=False, **kwargs):
+def parse_query(query, schema):
+    source = Source(query, name='GraphQL request')
+    ast = parse(source)
+    validation_errors = validate(schema, ast)
+    return ast, validation_errors
+
+
+def execute_graphql_request(schema, params, allow_only_query=False, parser=parse_query, **kwargs):
     if not params.query:
         raise HttpQueryError(400, 'Must provide query string.')
 
     try:
-        source = Source(params.query, name='GraphQL request')
-        ast = parse(source)
-        validation_errors = validate(schema, ast)
+        ast, validation_errors = parse_query(params.query, schema)
         if validation_errors:
             return ExecutionResult(
                 errors=validation_errors,


### PR DESCRIPTION
I've been checking per function performance on a project using Graphene, and it turns out the single biggest issue for simple queries is raw query parsing and subsequent conversion to AST.

The rationale for this PR is I've never seen anyone *not* at least caching queries at this step in production (some logging also usually happens here): enabling custom query parsing allows people to implement additional logic here without having to rewrite graphql-server-core (which they usually do for now).

A custom parsing step looks like this:
```python
def parse_query(query, schema):
    ...
    return ast, validation_errors
```

Some LRU cache or logging can now easily be added on top of this.

Please check the following commit to see how it would work in practice:
https://github.com/Hellzed/aiohttp-graphql/commit/2abe5d108bcf7309b08a2b2646c3818169404faa
  