### PR TITLE
Expose `HttpQueryError` in `__all__`

### DIFF
--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -203,6 +203,7 @@ def load_json_body(data):
 
 
 __all__ = [
+    "HttpQueryError",
     "default_format_error",
     "SkipException",
     "run_http_query",


### PR DESCRIPTION
`HttpQueryError` not part of `__all__` is a breaking change to libraries like `sanic-graphql` who rely on importing it:
https://github.com/graphql-python/sanic-graphql/blob/master/sanic_graphql/graphqlview.py#L12