### PR TITLE
ABCs should be imported from collections.abc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,16 @@
+*.pyo
 *.pyc
-.idea
-.cache
-.tox
+
 *.egg
 *.egg-info
-.coverage
-/build/
 
+.idea
+.cache
+.coverage
+.mypy_cache
+.pytest_cache
+.tox
+.venv
+
+/build/
 /dist/
-/.mypy_cache
-/.pytest_cache

--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -1,5 +1,9 @@
 import json
-from collections import namedtuple, MutableMapping
+from collections import namedtuple
+try:
+    from collections.abc import MutableMapping
+except ImportError:  # Python < 3.3
+    from collections import MutableMapping
 
 import six
 from graphql import get_default_backend

--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -13,9 +13,9 @@ from graphql.execution import ExecutionResult
 from .error import HttpQueryError
 
 # Necessary for static type checking
-if False:  # flake8: noqa
-    from typing import List, Dict, Optional, Tuple, Any, Union, Callable, Type
-    from graphql import GraphQLSchema, GraphQLBackend
+if False:
+    from typing import List, Dict, Optional, Tuple, Any, Union, Callable, Type  # noqa: F401
+    from graphql import GraphQLSchema, GraphQLBackend  # noqa: F401
 
 
 class SkipException(Exception):

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ max-line-length = 160
 [isort]
 known_first_party=graphql_server
 
-[pytest]
+[tool:pytest]
 norecursedirs = venv .tox .cache
 
 [bdist_wheel]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-required_packages = ["graphql-core>=2.1", "promise"]
+required_packages = ["graphql-core-next"]
 
 setup(
     name="graphql-server-core",
@@ -16,19 +16,14 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: Implementation :: PyPy",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: MIT License",
     ],
     keywords="api graphql protocol rest",
     packages=find_packages(exclude=["tests"]),
     install_requires=required_packages,
-    tests_require=["pytest>=2.7.3"],
+    tests_require=["pytest"],
     include_package_data=True,
     zip_safe=False,
     platforms="any",

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -10,17 +10,16 @@ def resolve_raises(*_):
 QueryRootType = GraphQLObjectType(
     name='QueryRoot',
     fields={
-        'thrower': GraphQLField(GraphQLNonNull(GraphQLString), resolver=resolve_raises),
-        'request': GraphQLField(GraphQLNonNull(GraphQLString),
-                                resolver=lambda obj, info: context.args.get('q')),
-        'context': GraphQLField(GraphQLNonNull(GraphQLString),
-                                resolver=lambda obj, info: context),
+        'thrower': GraphQLField(GraphQLNonNull(GraphQLString),
+                                resolve=resolve_raises),
+        'request': GraphQLField(GraphQLNonNull(GraphQLString)),
+        'context': GraphQLField(GraphQLNonNull(GraphQLString)),
         'test': GraphQLField(
-            type=GraphQLString,
+            type_=GraphQLString,
             args={
                 'who': GraphQLArgument(GraphQLString)
             },
-            resolver=lambda obj, info, who='World': 'Hello %s' % who
+            resolve=lambda obj, info, who='World': 'Hello %s' % who
         )
     }
 )
@@ -29,8 +28,8 @@ MutationRootType = GraphQLObjectType(
     name='MutationRoot',
     fields={
         'writeTest': GraphQLField(
-            type=QueryRootType,
-            resolver=lambda *_: QueryRootType
+            type_=QueryRootType,
+            resolve=lambda *_: QueryRootType
         )
     }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,33 @@
 [tox]
-envlist = flake8,import-order,py35,py27,py33,py34,pypy
+envlist = flake8,import-order,py36,py37
 skipsdist = true
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    pytest>=2.7.2
-    graphql-core>=2.1
+    pytest
+    graphql-core-next
     pytest-cov
 commands =
-    py{py,27,34,35,36}: py.test tests {posargs}
+    py{36,37}: py.test tests {posargs}
 
 [testenv:flake8]
-basepython=python3.6
+basepython=python3.7
 deps = flake8
 commands =
     flake8 graphql_server
 
 [testenv:mypy]
-basepython=python3.6
+basepython=python3.7
 deps = mypy
 commands =
     mypy graphql_server --ignore-missing-imports
 
 [testenv:import-order]
-basepython=python3.6
+basepython=python3.7
 deps =
     isort
-    graphql-core>=2.1
+    graphql-core-next
 commands =
     isort --check-only graphql_server/ -rc


### PR DESCRIPTION
Importing ABCs directly from the collections package instead of from
collections.abc is deprecated, and in Python 3.8 it will stop working.