### PR TITLE
Use graphql-core-next instead of graphql-core + support async

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-required_packages = ["graphql-core>=2.1", "promise"]
+required_packages = ["graphql-core-next>=1.0.2", "promise"]
 
 setup(
     name="graphql-server-core",
@@ -28,7 +28,7 @@ setup(
     keywords="api graphql protocol rest",
     packages=find_packages(exclude=["tests"]),
     install_requires=required_packages,
-    tests_require=["pytest>=2.7.3"],
+    tests_require=["pytest>=4.3.1"],
     include_package_data=True,
     zip_safe=False,
     platforms="any",


### PR DESCRIPTION
I made some adaptions to use this library together with [graphql-core-next](https://github.com/graphql-python/graphql-core-next)

The usage of `async` / `await` may not be desired in this repo for reasons that start with `2.x`. In that case, feel free to close/ignore.