### PR TITLE
Update setup.cfg [pytest] -> [tool:pytest]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ max-line-length = 160
 [isort]
 known_first_party=graphql_server
 
-[pytest]
+[tool:pytest]
 norecursedirs = venv .tox .cache
 
 [bdist_wheel]


### PR DESCRIPTION
https://travis-ci.org/graphql-python/graphql-server-core/jobs/516707376#L528
`Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.`

The latest Travis build suggested that change...