### PR TITLE
Return 200 errors

### DIFF
--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -294,7 +294,13 @@ def format_execution_result(
         if execution_result.errors:
             fe = [format_error(e) for e in execution_result.errors]  # type: ignore
             response = {"errors": fe}
-            status_code = 400
+
+            if execution_result.errors and any(
+                not getattr(e, "path", None) for e in execution_result.errors
+            ):
+                status_code = 400
+            else:
+                response["data"] = execution_result.data
         else:
             response = {"data": execution_result.data}
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     extras_require={
         "all": install_all_requires,
         "test": install_all_requires + tests_requires,
-        "dev": dev_requires,
+        "dev": install_all_requires + dev_requires,
         "flask": install_flask_requires,
     },
     include_package_data=True,

--- a/tests/flask/test_graphqlview.py
+++ b/tests/flask/test_graphqlview.py
@@ -371,7 +371,7 @@ def test_supports_pretty_printing_by_request(app, client):
 
 def test_handles_field_errors_caught_by_graphql(app, client):
     response = client.get(url_string(app, query="{thrower}"))
-    assert response.status_code == 400
+    assert response.status_code == 200
     assert response_json(response) == {
         "errors": [
             {
@@ -379,7 +379,8 @@ def test_handles_field_errors_caught_by_graphql(app, client):
                 "path": ["thrower"],
                 "message": "Throws!",
             }
-        ]
+        ],
+        "data": None,
     }
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -105,8 +105,9 @@ def test_encode_execution_results_with_error():
                 "path": ["somePath"],
             }
         ],
+        "data": None,
     }
-    assert output.status_code == 400
+    assert output.status_code == 200
 
 
 def test_encode_execution_results_with_empty_result():
@@ -148,8 +149,9 @@ def test_encode_execution_results_with_format_error():
     assert isinstance(output.status_code, int)
     assert json.loads(output.body) == {
         "errors": [{"msg": "Some msg", "loc": "1:2", "pth": "some/path"}],
+        "data": None,
     }
-    assert output.status_code == 400
+    assert output.status_code == 200
 
 
 def test_encode_execution_results_with_batch():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -92,6 +92,9 @@ def test_allows_get_with_operation_name():
         {"data": {"test": "Hello World", "shared": "Hello Everyone"}, "errors": None}
     ]
 
+    response = encode_execution_results(results)
+    assert response.status_code == 200
+
 
 def test_reports_validation_errors():
     results, params = run_http_query(
@@ -115,6 +118,9 @@ def test_reports_validation_errors():
             ],
         }
     ]
+
+    response = encode_execution_results(results)
+    assert response.status_code == 400
 
 
 def test_non_dict_params_in_non_batch_query():
@@ -397,6 +403,9 @@ def test_handles_field_errors_caught_by_graphql():
     assert results == [
         (None, [{"message": "Throws!", "locations": [(1, 2)], "path": ["thrower"]}])
     ]
+
+    response = encode_execution_results(results)
+    assert response.status_code == 200
 
 
 def test_handles_syntax_errors_caught_by_graphql():


### PR DESCRIPTION
This PR modifies the logic that determines the HTTP status code to follow the v2 behaviour (see https://github.com/graphql-python/graphql-server-core/pull/36#discussion_r407592638). A HTTP 400 response should only be returned only when the errors are not specific to a particular part of the query (a validation error for example) otherwise a HTTP 200 response should be returned.