### PR TITLE
Remove references to executor in Flask view

### DIFF
--- a/graphql_server/flask/graphqlview.py
+++ b/graphql_server/flask/graphqlview.py
@@ -19,7 +19,6 @@ from .render_graphiql import render_graphiql
 
 class GraphQLView(View):
     schema = None
-    executor = None
     root_value = None
     pretty = False
     graphiql = False
@@ -51,9 +50,6 @@ class GraphQLView(View):
     def get_middleware(self):
         return self.middleware
 
-    def get_executor(self):
-        return self.executor
-
     def render_graphiql(self, params, result):
         return render_graphiql(
             params=params,
@@ -76,13 +72,6 @@ class GraphQLView(View):
 
             pretty = self.pretty or show_graphiql or request.args.get("pretty")
 
-            extra_options = {}
-            executor = self.get_executor()
-            if executor:
-                # We only include it optionally since
-                # executor is not a valid argument in all backends
-                extra_options["executor"] = executor
-
             execution_results, all_params = run_http_query(
                 self.schema,
                 request_method,
@@ -94,7 +83,6 @@ class GraphQLView(View):
                 root_value=self.get_root_value(),
                 context_value=self.get_context_value(),
                 middleware=self.get_middleware(),
-                **extra_options
             )
             result, status_code = encode_execution_results(
                 execution_results,


### PR DESCRIPTION
Missed this in the review but executor is no longer a supported feature of graphql-core.