### PR TITLE
Expose version number as __version__

### DIFF
--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -18,8 +18,16 @@ from graphql.graphql import graphql, graphql_sync
 from graphql.pyutils import AwaitableOrValue
 
 from .error import HttpQueryError
+from .version import version, version_info
+
+# The GraphQL-Server 3 version info.
+
+__version__ = version
+__version_info__ = version_info
 
 __all__ = [
+    "version",
+    "version_info",
     "run_http_query",
     "encode_execution_results",
     "load_json_body",

--- a/graphql_server/version.py
+++ b/graphql_server/version.py
@@ -1,0 +1,44 @@
+import re
+from typing import NamedTuple
+
+__all__ = ["version", "version_info"]
+
+
+version = "2.0.0"
+
+_re_version = re.compile(r"(\d+)\.(\d+)\.(\d+)(\D*)(\d*)")
+
+
+class VersionInfo(NamedTuple):
+    major: int
+    minor: int
+    micro: int
+    releaselevel: str
+    serial: int
+
+    @classmethod
+    def from_str(cls, v: str) -> "VersionInfo":
+        groups = _re_version.match(v).groups()  # type: ignore
+        major, minor, micro = map(int, groups[:3])
+        level = (groups[3] or "")[:1]
+        if level == "a":
+            level = "alpha"
+        elif level == "b":
+            level = "beta"
+        elif level in ("c", "r"):
+            level = "candidate"
+        else:
+            level = "final"
+        serial = groups[4]
+        serial = int(serial) if serial else 0
+        return cls(major, minor, micro, level, serial)
+
+    def __str__(self) -> str:
+        v = f"{self.major}.{self.minor}.{self.micro}"
+        level = self.releaselevel
+        if level and level != "final":
+            v = f"{v}{level[:1]}{self.serial}"
+        return v
+
+
+version_info = VersionInfo.from_str(version)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from re import search
 from setuptools import setup, find_packages
 
 install_requires = [
@@ -44,11 +45,17 @@ install_all_requires = \
     install_webob_requires + \
     install_aiohttp_requires
 
+with open("graphql_server/version.py") as version_file:
+    version = search('version = "(.*)"', version_file.read()).group(1)
+
+with open("README.md", encoding="utf-8") as readme_file:
+    readme = readme_file.read()
+
 setup(
     name="graphql-server-core",
-    version="2.0.0",
+    version=version,
     description="GraphQL Server tools for powering your server",
-    long_description=open("README.md", encoding="utf-8").read(),
+    long_description=readme,
     long_description_content_type="text/markdown",
     url="https://github.com/graphql-python/graphql-server-core",
     download_url="https://github.com/graphql-python/graphql-server-core/releases",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""GraphQL-Server-Core Tests"""
+"""GraphQL-Server Tests"""

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,78 @@
+import re
+
+import graphql_server
+from graphql_server.version import VersionInfo, version, version_info
+
+_re_version = re.compile(r"(\d+)\.(\d+)\.(\d+)(?:([abc])(\d+))?$")
+
+
+def test_create_version_info_from_fields():
+    v = VersionInfo(1, 2, 3, "alpha", 4)
+    assert v.major == 1
+    assert v.minor == 2
+    assert v.micro == 3
+    assert v.releaselevel == "alpha"
+    assert v.serial == 4
+
+
+def test_create_version_info_from_str():
+    v = VersionInfo.from_str("1.2.3")
+    assert v.major == 1
+    assert v.minor == 2
+    assert v.micro == 3
+    assert v.releaselevel == "final"
+    assert v.serial == 0
+    v = VersionInfo.from_str("1.2.3a4")
+    assert v.major == 1
+    assert v.minor == 2
+    assert v.micro == 3
+    assert v.releaselevel == "alpha"
+    assert v.serial == 4
+    v = VersionInfo.from_str("1.2.3beta4")
+    assert v.major == 1
+    assert v.minor == 2
+    assert v.micro == 3
+    assert v.releaselevel == "beta"
+    assert v.serial == 4
+    v = VersionInfo.from_str("12.34.56rc789")
+    assert v.major == 12
+    assert v.minor == 34
+    assert v.micro == 56
+    assert v.releaselevel == "candidate"
+    assert v.serial == 789
+
+
+def test_serialize_as_str():
+    v = VersionInfo(1, 2, 3, "final", 0)
+    assert str(v) == "1.2.3"
+    v = VersionInfo(1, 2, 3, "alpha", 4)
+    assert str(v) == "1.2.3a4"
+
+
+def test_base_package_has_correct_version():
+    assert graphql_server.__version__ == version
+    assert graphql_server.version == version
+
+
+def test_base_package_has_correct_version_info():
+    assert graphql_server.__version_info__ is version_info
+    assert graphql_server.version_info is version_info
+
+
+def test_version_has_correct_format():
+    assert isinstance(version, str)
+    assert _re_version.match(version)
+
+
+def test_version_info_has_correct_fields():
+    assert isinstance(version_info, tuple)
+    assert str(version_info) == version
+    groups = _re_version.match(version).groups()  # type: ignore
+    assert version_info.major == int(groups[0])
+    assert version_info.minor == int(groups[1])
+    assert version_info.micro == int(groups[2])
+    if groups[3] is None:  # pragma: no cover
+        assert groups[4] is None
+    else:  # pragma: no cover
+        assert version_info.releaselevel[:1] == groups[3]
+        assert version_info.serial == int(groups[4])


### PR DESCRIPTION
Fixes #47 based on graphql-core logic to handle package version.