### PR TITLE
Run additional parse step only when necessary (#43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .nox/
+.venv/
 .coverage
 .coverage.*
 .cache

--- a/graphql_server/__init__.py
+++ b/graphql_server/__init__.py
@@ -236,23 +236,23 @@ def get_response(
         if not params.query:
             raise HttpQueryError(400, "Must provide query string.")
 
-        # Parse document to trigger a new HttpQueryError if allow_only_query is True
-        try:
-            document = parse(params.query)
-        except GraphQLError as e:
-            return ExecutionResult(data=None, errors=[e])
-        except Exception as e:
-            e = GraphQLError(str(e), original_error=e)
-            return ExecutionResult(data=None, errors=[e])
-
         if allow_only_query:
+            # Parse document to check that only query operations are used
+            try:
+                document = parse(params.query)
+            except GraphQLError as e:
+                return ExecutionResult(data=None, errors=[e])
+            except Exception as e:
+                e = GraphQLError(str(e), original_error=e)
+                return ExecutionResult(data=None, errors=[e])
             operation_ast = get_operation_ast(document, params.operation_name)
             if operation_ast:
                 operation = operation_ast.operation.value
                 if operation != OperationType.QUERY.value:
                     raise HttpQueryError(
                         405,
-                        f"Can only perform a {operation} operation from a POST request.",  # noqa
+                        f"Can only perform a {operation} operation"
+                        " from a POST request.",
                         headers={"Allow": "POST"},
                     )
 


### PR DESCRIPTION
This is a preliminary fix for #43. As final fix should refactor to use `execute` instead of `graphql/graphql_sync` in order to separate the validation from the execution.