### PR TITLE
Add graphiql options and missing flask context

### DIFF
--- a/graphql_server/aiohttp/graphqlview.py
+++ b/graphql_server/aiohttp/graphqlview.py
@@ -19,6 +19,7 @@ from graphql_server import (
 from graphql_server.render_graphiql import (
     GraphiQLConfig,
     GraphiQLData,
+    GraphiQLOptions,
     render_graphiql_async,
 )
 
@@ -39,6 +40,9 @@ class GraphQLView:
     enable_async = False
     subscriptions = None
     headers = None
+    default_query = None
+    header_editor_enabled = None
+    should_persist_headers = None
 
     accepted_methods = ["GET", "POST", "PUT", "DELETE"]
 
@@ -174,8 +178,13 @@ class GraphQLView:
                     graphiql_html_title=self.graphiql_html_title,
                     jinja_env=self.jinja_env,
                 )
+                graphiql_options = GraphiQLOptions(
+                    default_query=self.default_query,
+                    header_editor_enabled=self.header_editor_enabled,
+                    should_persist_headers=self.should_persist_headers,
+                )
                 source = await render_graphiql_async(
-                    data=graphiql_data, config=graphiql_config
+                    data=graphiql_data, config=graphiql_config, options=graphiql_options
                 )
                 return web.Response(text=source, content_type="text/html")
 

--- a/graphql_server/render_graphiql.py
+++ b/graphql_server/render_graphiql.py
@@ -201,7 +201,7 @@ class GraphiQLOptions(TypedDict):
 
     default_query
         An optional GraphQL string to use when no query is provided and no stored
-        query exists from a previous session.  If undefined is provided, GraphiQL
+        query exists from a previous session. If None is provided, GraphiQL
         will use its own default query.
     header_editor_enabled
         An optional boolean which enables the header editor when true.

--- a/graphql_server/sanic/graphqlview.py
+++ b/graphql_server/sanic/graphqlview.py
@@ -21,6 +21,7 @@ from graphql_server import (
 from graphql_server.render_graphiql import (
     GraphiQLConfig,
     GraphiQLData,
+    GraphiQLOptions,
     render_graphiql_async,
 )
 
@@ -41,6 +42,9 @@ class GraphQLView(HTTPMethodView):
     enable_async = False
     subscriptions = None
     headers = None
+    default_query = None
+    header_editor_enabled = None
+    should_persist_headers = None
 
     methods = ["GET", "POST", "PUT", "DELETE"]
 
@@ -127,8 +131,15 @@ class GraphQLView(HTTPMethodView):
                         graphiql_html_title=self.graphiql_html_title,
                         jinja_env=self.jinja_env,
                     )
+                    graphiql_options = GraphiQLOptions(
+                        default_query=self.default_query,
+                        header_editor_enabled=self.header_editor_enabled,
+                        should_persist_headers=self.should_persist_headers,
+                    )
                     source = await render_graphiql_async(
-                        data=graphiql_data, config=graphiql_config
+                        data=graphiql_data,
+                        config=graphiql_config,
+                        options=graphiql_options,
                     )
                     return html(source)
 

--- a/graphql_server/webob/graphqlview.py
+++ b/graphql_server/webob/graphqlview.py
@@ -19,6 +19,7 @@ from graphql_server import (
 from graphql_server.render_graphiql import (
     GraphiQLConfig,
     GraphiQLData,
+    GraphiQLOptions,
     render_graphiql_sync,
 )
 
@@ -38,6 +39,9 @@ class GraphQLView:
     enable_async = False
     subscriptions = None
     headers = None
+    default_query = None
+    header_editor_enabled = None
+    should_persist_headers = None
     charset = "UTF-8"
 
     def __init__(self, **kwargs):
@@ -117,8 +121,17 @@ class GraphQLView:
                     graphiql_html_title=self.graphiql_html_title,
                     jinja_env=None,
                 )
+                graphiql_options = GraphiQLOptions(
+                    default_query=self.default_query,
+                    header_editor_enabled=self.header_editor_enabled,
+                    should_persist_headers=self.should_persist_headers,
+                )
                 return Response(
-                    render_graphiql_sync(data=graphiql_data, config=graphiql_config),
+                    render_graphiql_sync(
+                        data=graphiql_data,
+                        config=graphiql_config,
+                        options=graphiql_options,
+                    ),
                     charset=self.charset,
                     content_type="text/html",
                 )

--- a/tests/aiohttp/schema.py
+++ b/tests/aiohttp/schema.py
@@ -24,8 +24,17 @@ QueryRootType = GraphQLObjectType(
             resolve=lambda obj, info, *args: info.context["request"].query.get("q"),
         ),
         "context": GraphQLField(
-            GraphQLNonNull(GraphQLString),
-            resolve=lambda obj, info, *args: info.context["request"],
+            GraphQLObjectType(
+                name="context",
+                fields={
+                    "session": GraphQLField(GraphQLString),
+                    "request": GraphQLField(
+                        GraphQLNonNull(GraphQLString),
+                        resolve=lambda obj, info: info.context["request"],
+                    ),
+                },
+            ),
+            resolve=lambda obj, info: info.context,
         ),
         "test": GraphQLField(
             type_=GraphQLString,

--- a/tests/flask/schema.py
+++ b/tests/flask/schema.py
@@ -21,8 +21,17 @@ QueryRootType = GraphQLObjectType(
             resolve=lambda obj, info: info.context["request"].args.get("q"),
         ),
         "context": GraphQLField(
-            GraphQLNonNull(GraphQLString),
-            resolve=lambda obj, info: info.context["request"],
+            GraphQLObjectType(
+                name="context",
+                fields={
+                    "session": GraphQLField(GraphQLString),
+                    "request": GraphQLField(
+                        GraphQLNonNull(GraphQLString),
+                        resolve=lambda obj, info: info.context["request"],
+                    ),
+                },
+            ),
+            resolve=lambda obj, info: info.context,
         ),
         "test": GraphQLField(
             type_=GraphQLString,

--- a/tests/flask/schema.py
+++ b/tests/flask/schema.py
@@ -18,10 +18,11 @@ QueryRootType = GraphQLObjectType(
         "thrower": GraphQLField(GraphQLNonNull(GraphQLString), resolve=resolve_raises),
         "request": GraphQLField(
             GraphQLNonNull(GraphQLString),
-            resolve=lambda obj, info: info.context.args.get("q"),
+            resolve=lambda obj, info: info.context["request"].args.get("q"),
         ),
         "context": GraphQLField(
-            GraphQLNonNull(GraphQLString), resolve=lambda obj, info: info.context
+            GraphQLNonNull(GraphQLString),
+            resolve=lambda obj, info: info.context["request"],
         ),
         "test": GraphQLField(
             type_=GraphQLString,

--- a/tests/flask/test_graphqlview.py
+++ b/tests/flask/test_graphqlview.py
@@ -491,35 +491,28 @@ def test_passes_request_into_request_context(app, client):
 
 @pytest.mark.parametrize("app", [create_app(context={"session": "CUSTOM CONTEXT"})])
 def test_passes_custom_context_into_context(app, client):
-    response = client.get(url_string(app, query="{context { session }}"))
+    response = client.get(url_string(app, query="{context { session request }}"))
 
-    print(response_json(response))
     assert response.status_code == 200
-    assert "data" in response_json(response)
-    assert "session" in response_json(response)["data"]["context"]
-    assert "CUSTOM CONTEXT" in response_json(response)["data"]["context"]["session"]
-
-
-@pytest.mark.parametrize("app", [create_app(context={"session": "CUSTOM CONTEXT"})])
-def test_context_remapped_if_mapping(app, client):
-    response = client.get(url_string(app, query="{context { request }}"))
-
-    print(response_json(response))
-    assert response.status_code == 200
-    assert "data" in response_json(response)
-    assert "request" in response_json(response)["data"]["context"]
-    assert "Request" in response_json(response)["data"]["context"]["request"]
+    res = response_json(response)
+    assert "data" in res
+    assert "session" in res["data"]["context"]
+    assert "request" in res["data"]["context"]
+    assert "CUSTOM CONTEXT" in res["data"]["context"]["session"]
+    assert "Request" in res["data"]["context"]["request"]
 
 
 @pytest.mark.parametrize("app", [create_app(context="CUSTOM CONTEXT")])
 def test_context_remapped_if_not_mapping(app, client):
-    response = client.get(url_string(app, query="{context { request }}"))
+    response = client.get(url_string(app, query="{context { session request }}"))
 
-    print(response_json(response))
     assert response.status_code == 200
-    assert "data" in response_json(response)
-    assert "request" in response_json(response)["data"]["context"]
-    assert "CUSTOM CONTEXT" not in response_json(response)["data"]["context"]["request"]
+    res = response_json(response)
+    assert "data" in res
+    assert "session" in res["data"]["context"]
+    assert "request" in res["data"]["context"]
+    assert "CUSTOM CONTEXT" not in res["data"]["context"]["request"]
+    assert "Request" in res["data"]["context"]["request"]
 
 
 def test_post_multipart_data(app, client):

--- a/tests/flask/test_graphqlview.py
+++ b/tests/flask/test_graphqlview.py
@@ -489,13 +489,37 @@ def test_passes_request_into_request_context(app, client):
     assert response_json(response) == {"data": {"request": "testing"}}
 
 
-@pytest.mark.parametrize("app", [create_app(context="CUSTOM CONTEXT")])
+@pytest.mark.parametrize("app", [create_app(context={"session": "CUSTOM CONTEXT"})])
 def test_passes_custom_context_into_context(app, client):
-    response = client.get(url_string(app, query="{context}"))
+    response = client.get(url_string(app, query="{context { session }}"))
 
+    print(response_json(response))
     assert response.status_code == 200
     assert "data" in response_json(response)
-    assert "Request" in response_json(response)["data"]["context"]
+    assert "session" in response_json(response)["data"]["context"]
+    assert "CUSTOM CONTEXT" in response_json(response)["data"]["context"]["session"]
+
+
+@pytest.mark.parametrize("app", [create_app(context={"session": "CUSTOM CONTEXT"})])
+def test_context_remapped_if_mapping(app, client):
+    response = client.get(url_string(app, query="{context { request }}"))
+
+    print(response_json(response))
+    assert response.status_code == 200
+    assert "data" in response_json(response)
+    assert "request" in response_json(response)["data"]["context"]
+    assert "Request" in response_json(response)["data"]["context"]["request"]
+
+
+@pytest.mark.parametrize("app", [create_app(context="CUSTOM CONTEXT")])
+def test_context_remapped_if_not_mapping(app, client):
+    response = client.get(url_string(app, query="{context { request }}"))
+
+    print(response_json(response))
+    assert response.status_code == 200
+    assert "data" in response_json(response)
+    assert "request" in response_json(response)["data"]["context"]
+    assert "CUSTOM CONTEXT" not in response_json(response)["data"]["context"]["request"]
 
 
 def test_post_multipart_data(app, client):

--- a/tests/flask/test_graphqlview.py
+++ b/tests/flask/test_graphqlview.py
@@ -489,14 +489,13 @@ def test_passes_request_into_request_context(app, client):
     assert response_json(response) == {"data": {"request": "testing"}}
 
 
-@pytest.mark.parametrize(
-    "app", [create_app(get_context_value=lambda: "CUSTOM CONTEXT")]
-)
+@pytest.mark.parametrize("app", [create_app(context="CUSTOM CONTEXT")])
 def test_passes_custom_context_into_context(app, client):
     response = client.get(url_string(app, query="{context}"))
 
     assert response.status_code == 200
-    assert response_json(response) == {"data": {"context": "CUSTOM CONTEXT"}}
+    assert "data" in response_json(response)
+    assert "Request" in response_json(response)["data"]["context"]
 
 
 def test_post_multipart_data(app, client):

--- a/tests/sanic/schema.py
+++ b/tests/sanic/schema.py
@@ -24,8 +24,17 @@ QueryRootType = GraphQLObjectType(
             resolve=lambda obj, info: info.context["request"].args.get("q"),
         ),
         "context": GraphQLField(
-            GraphQLNonNull(GraphQLString),
-            resolve=lambda obj, info: info.context["request"],
+            GraphQLObjectType(
+                name="context",
+                fields={
+                    "session": GraphQLField(GraphQLString),
+                    "request": GraphQLField(
+                        GraphQLNonNull(GraphQLString),
+                        resolve=lambda obj, info: info.context["request"],
+                    ),
+                },
+            ),
+            resolve=lambda obj, info: info.context,
         ),
         "test": GraphQLField(
             type_=GraphQLString,

--- a/tests/webob/schema.py
+++ b/tests/webob/schema.py
@@ -22,8 +22,17 @@ QueryRootType = GraphQLObjectType(
             resolve=lambda obj, info: info.context["request"].params.get("q"),
         ),
         "context": GraphQLField(
-            GraphQLNonNull(GraphQLString),
-            resolve=lambda obj, info: info.context["request"],
+            GraphQLObjectType(
+                name="context",
+                fields={
+                    "session": GraphQLField(GraphQLString),
+                    "request": GraphQLField(
+                        GraphQLNonNull(GraphQLString),
+                        resolve=lambda obj, info: info.context["request"],
+                    ),
+                },
+            ),
+            resolve=lambda obj, info: info.context,
         ),
         "test": GraphQLField(
             type_=GraphQLString,


### PR DESCRIPTION
This add support for graphiql options like as:

* `default_query`: An optional GraphQL string to use when no query is provided and no stored query exists from a previous session. If not provided, GraphiQL will use its own default query.
* `header_editor_enabled`: An optional boolean which enables the header editor when true. Defaults to **false**.
* `should_persist_headers`:  An optional boolean which enables to persist headers to storage when true. Defaults to **false**.

Also, add the missing `context` attribute as requested at this old [flask-graphql#52](https://github.com/graphql-python/flask-graphql/issues/52) issue.

However, the approach I used for all 4 servers (flask, aiohttp, webob, sanic) was based on this [sanic#8](https://github.com/graphql-python/sanic-graphql/issues/8) issue which was solved at this [pull request](https://github.com/graphql-python/sanic-graphql/pull/9).

There are other related issues as well on each server integrations:

- https://github.com/graphql-python/sanic-graphql/issues/11
- https://github.com/graphql-python/flask-graphql/issues/45
- https://github.com/graphql-python/webob-graphql/issues/5

As far as I know, this `context` will be passed to the `execute` method on GraphQL, which will be passed to all resolve functions as stated on [GraphQL-JS docs](https://graphql.org/graphql-js/graphql/#graphql). At the end, this will be part of the `GraphQLResolveInfo`, which is used by [resolve_field_value_or_error](https://github.com/graphql-python/graphql-core/blob/master/src/graphql/execution/execute.py#L564) to resolve the field.

Based on that, I am not 100% sure if it the correct way of handling custom context for all server integrations so any suggestion is welcome!